### PR TITLE
Fix task for Darwin OS

### DIFF
--- a/tasks/git-committers.js
+++ b/tasks/git-committers.js
@@ -82,7 +82,7 @@ module.exports = function (grunt) {
 
 
             //detect current system use the appropriate terminal
-            if (/win/.test(process.platform)) {
+            if (/win32/.test(process.platform)) {
                 cmd += ' < CON';
             } else {
                 cmd += ' < /dev/tty';

--- a/test/expected/AUTHORS.txt
+++ b/test/expected/AUTHORS.txt
@@ -1,3 +1,4 @@
 Denis Ciccale
 lucian.enache
 Lucian Enache
+Robert Rossmann


### PR DESCRIPTION
OS X identifies itself as **darwin**, which means the condition `/win/.test(process.platform)` passes for OS X. This patch fixes this behaviour.
